### PR TITLE
Add schema.rb to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ config/initializers/secret_token.rb
 config/master.key
 
 config/database.yml
+db/schema.rb
 
 
 # Only include if you have production secrets in this file, which is no longer a Rails default


### PR DESCRIPTION
I think this file should be in **.gitignore** since it is generated automatically after migration.